### PR TITLE
Read xml safely

### DIFF
--- a/R/count_identifiers.R
+++ b/R/count_identifiers.R
@@ -25,7 +25,7 @@ count_identifiers <- function(url = "http://oai.datacite.org/oai", prefix = 'oai
 
 ci <- function(x, args, ...) {
   res <- GET(x, query = args, ...)
-  xml <- xml2::read_xml(content(res, "text"))
+  xml <- read_xml_safely(content(res, "text"))
   children <- xml_children(xml_children(xml))
   count <- as.numeric(
     xml_attr(

--- a/R/get_record.R
+++ b/R/get_record.R
@@ -33,7 +33,7 @@ each_record <- function(identifier, url, prefix, as, ...) {
   res <- GET(url, query = args, ...)
   stop_for_status(res)
   tt <- content(res, "text")
-  xml_orig <- xml2::read_xml(tt)
+  xml_orig <- read_xml_safely(tt)
   handle_errors(xml_orig)
   if (as == "raw") {
     tt

--- a/R/id.R
+++ b/R/id.R
@@ -21,5 +21,5 @@ id <- function(url, ...) {
 id_ <- function(x, ...) {
   res <- GET(x, query = list(verb = "Identify"), ...)
   tt <- content(res, as = "text")
-  get_headers(xml_children(xml2::read_xml(tt))[[3]])
+  get_headers(xml_children(read_xml_safely(tt))[[3]])
 }

--- a/R/list_metadataformats.R
+++ b/R/list_metadataformats.R
@@ -31,6 +31,6 @@ one_mf <- function(identifier, url, ...) {
   res <- GET(url, query = args, ...)
   stop_for_status(res)
   out <- content(res, "text")
-  xml <- xml2::read_xml(out)
+  xml <- read_xml_safely(out)
   rbind_fill(lapply(xml_children(xml_children(xml)[[3]]), get_headers))
 }

--- a/R/read_xml_safely.R
+++ b/R/read_xml_safely.R
@@ -1,0 +1,56 @@
+# Parsing XML while trying to catch (some) exceptions
+#
+# The catching involves two steps:
+#
+# 1. The "net", currently `error_handler` for errors, that based on the content
+# of the thrown exception invokes a particular restart function. Further
+# handlers can be added for other types of exceptions (e.g. warnings, etc.).
+#
+# 2. A (set of) restart functions that are appropriately invoked by the
+# handlers. Restarts should try to modify the object 'x' in the parent
+# frame and re-run the parsing.
+#
+# Handling additional exceptions requires two steps:
+#
+# 1. Expand the existing, or add a new, exception handler that is called by
+# `tryCatch` and trigger a neccessary restart function.
+#
+# 2. Write a restart function that will modify the `read_xml` input in the
+# parent frame.
+
+read_xml_safely <- function(x, ...)
+{
+  # Handlers:
+
+  # Handles *errors* thrown by xml2::read_xml
+  error_handler <- function(er) {
+    # Catch invalid characters in XML
+    if(grepl("PCDATA invalid Char value", er$message)) {
+      msg <- paste0("invalid characters in XML:\n",
+                    er$message,
+                    "\n",
+                    "Removing")
+      warning(msg)
+      invokeRestart("drop_invalid_chars")
+    } else {
+      return(er)
+    }
+  }
+
+  # Try to `read_xml` with restarts
+  repeat {
+    withRestarts(
+      tryCatch(
+        return( xml2::read_xml(x, ...) ),
+        error = error_handler
+      ),
+
+      # Restart functions that should modify `x` in the *parent frame*
+
+      # Remove UTF-8 characters that are invalid in XML
+      drop_invalid_chars = function() {
+        x <<- gsub("[^\u9\uA\uD\u20-\uD7FF\uE000-\uFFFD\u10000-\u10FFFF]", "", x, perl=TRUE)
+      }
+    )
+  }
+}

--- a/R/while_oai.R
+++ b/R/while_oai.R
@@ -16,7 +16,7 @@ while_oai <- function(url, args, token, as, ...) {
     res <- GET(url, query = args2, ...)
     stop_for_status(res)
     tt <- content(res, "text")
-    xml_orig <- xml2::read_xml(tt)
+    xml_orig <- read_xml_safely(tt)
     handle_errors(xml_orig)
     xml <- xml2::xml_children(xml2::xml_children(xml_orig)[[3]])
     trytok <- xml2::as_list(xml[sapply(xml, xml_name) == "resumptionToken"])

--- a/tests/testthat/test-read_xml_safely.R
+++ b/tests/testthat/test-read_xml_safely.R
@@ -6,13 +6,15 @@ inputs <- c(
 )
 
 test_that("proper XML is parsed correctly", {
-  expect_equal( read_xml_safely(inputs[1]), xml2::read_xml(inputs[1]) )
+  expect_equal( as.character(read_xml_safely(inputs[1])),
+                as.character(xml2::read_xml(inputs[1])) )
 } )
 
 
 test_that("RESTART: improper characters are translated", {
   expect_warning( res <- read_xml_safely(inputs[2]) )
-  expect_equal(res, xml2::read_xml( gsub("\u0019", "", inputs[2]) ))
+  expect_equal( as.character(res),
+                as.character(xml2::read_xml( gsub("\u0019", "", inputs[2]))) )
 } )
 
 

--- a/tests/testthat/test-read_xml_safely.R
+++ b/tests/testthat/test-read_xml_safely.R
@@ -1,0 +1,18 @@
+context("Safe reading of XMLs")
+
+inputs <- c(
+  "<p>Some paragraph with <b>text in bold</b> which should be OK</p>",
+  "<p>Some paragraph with <b>also in bold</b> with a an illegal character \u0019</p>"
+)
+
+test_that("proper XML is parsed correctly", {
+  expect_equal( read_xml_safely(inputs[1]), xml2::read_xml(inputs[1]) )
+} )
+
+
+test_that("RESTART: improper characters are translated", {
+  expect_warning( res <- read_xml_safely(inputs[2]) )
+  expect_equal(res, xml2::read_xml( gsub("\u0019", "", inputs[2]) ))
+} )
+
+


### PR DESCRIPTION
I mentioned this in #10: https://github.com/sckott/oai/issues/10#issuecomment-143072521

When parsing an XML containing illegal characters `libxml` throws an error like

```
PCDATA invalid Char value 25 [9]
```

`read_xml_safely` catches the error, removes the characters, and gives a warning.

See also: http://stackoverflow.com/questions/26938905/perl-xmllibxml-parsing-issue-of-invalid-char


