### PR TITLE
Oai pmh errors

### DIFF
--- a/R/handle_errors.R
+++ b/R/handle_errors.R
@@ -1,12 +1,37 @@
 # Look for OAI-PMH exceptions
 # https://www.openarchives.org/OAI/openarchivesprotocol.html#ErrorConditions
 # xml = parsed xml
-handle_errors <- function(xml) {
-  nodeset <- xml2::xml_find_all(xml, ".//*[local-name()='error']")
-  if( length(nodeset) > 0 ) {
-    msgs <- sapply(nodeset, function(n)
-      paste0( xml2::xml_attr(n, "code"), ": ", xml2::xml_text(n) ) )
-    stop( paste0("OAI-PMH exceptions: ", paste(msgs, collapse="\n")) )
-  }
+# Return TRUE if OK or stop
+# handle_errors <- function(xml) {
+#   nodeset <- xml2::xml_find_all(xml, ".//*[local-name()='error']")
+#   if( length(nodeset) > 0 ) {
+#     msgs <- sapply(nodeset, function(n)
+#       paste0( xml2::xml_attr(n, "code"), ": ", xml2::xml_text(n) ) )
+#     stop( paste0("OAI-PMH exceptions: ", paste(msgs, collapse="\n")) )
+#   }
+#
+# }
+#
 
+
+
+
+handle_errors <- function(xml) {
+  # find error tags
+  req <- xml2::xml_text(xml2::xml_find_one(xml, ".//*[local-name()='request']" ))
+  nodeset <- xml2::xml_find_all(xml, ".//*[local-name()='error']")
+  # collect error information, if any
+  if( length(nodeset) == 0 ) {
+    return(TRUE)
+  } else {
+    errors <- lapply(nodeset, function(n)
+      c(code=xml2::xml_attr(n, "code"),
+        message=xml2::xml_text(n) ) )
+    cond <- condition(c("oai-pmh_error", "error"),
+                      message = paste0("OAI-PMH errors: ",
+                                       paste( sapply(errors, paste, collapse=": "), collapse=",\n")),
+                      request=req,
+                      error_codes = sapply(errors, "[", "code") )
+    stop(cond)
+  }
 }

--- a/R/handle_errors.R
+++ b/R/handle_errors.R
@@ -1,0 +1,12 @@
+# Look for OAI-PMH exceptions
+# https://www.openarchives.org/OAI/openarchivesprotocol.html#ErrorConditions
+# xml = parsed xml
+handle_errors <- function(xml) {
+  nodeset <- xml2::xml_find_all(xml, ".//*[local-name()='error']")
+  if( length(nodeset) > 0 ) {
+    msgs <- sapply(nodeset, function(n)
+      paste0( xml2::xml_attr(n, "code"), ": ", xml2::xml_text(n) ) )
+    stop( paste0("OAI-PMH exceptions: ", paste(msgs, collapse="\n")) )
+  }
+
+}

--- a/R/list_records.R
+++ b/R/list_records.R
@@ -70,18 +70,6 @@ is.url <- function(x, ...){
 }
 
 
-# Look for OAI-PMH exceptions
-# https://www.openarchives.org/OAI/openarchivesprotocol.html#ErrorConditions
-# xml = parsed xml
-handle_errors <- function(xml) {
-  nodeset <- xml2::xml_find_all(xml, ".//*[local-name()='error']")
-  if( length(nodeset) > 0 ) {
-    msgs <- sapply(nodeset, function(n)
-      paste0( xml2::xml_attr(n, "code"), ": ", xml2::xml_text(n) ) )
-    stop( paste0("OAI-PMH exceptions: ", paste(msgs, collapse="\n")) )
-  }
-
-}
 
 #' @export
 print.oai_df <- function(x, ..., n = 10) {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -11,3 +11,20 @@ pluck <- function(x, name, type) {
 last <- function(x) x[length(x)][[1]]
 
 datacite_base <- function() "http://oai.datacite.org/oai"
+
+
+
+
+
+# Simple condition generator as shown here
+# http://adv-r.had.co.nz/Exceptions-Debugging.html#condition-handling
+condition <- function(subclass, message, call = sys.call(-1), ...) {
+  structure(
+    class = unique(c(subclass, "condition")),
+    list(message = message, call = call),
+    ...
+  )
+}
+
+# is it a condition?
+is.condition <- function(x) inherits(x, "condition")

--- a/tests/testthat/test-handle_errors.R
+++ b/tests/testthat/test-handle_errors.R
@@ -1,18 +1,81 @@
 context("Handling OAI-PMH errors")
 
+# URLs triggering OAI-PMH errors
+tomorrow <- as.character(Sys.Date() + 1)
+error_url <- list(
+  badArgument="http://arXiv.org/oai2?verb=ListRecords&metadataPrefix=oai_dc&foo=bar",
+  badResumptionToken="http://oai.datacite.org/oai?verb=ListRecords&resumptionToken=foobar",
+  badVerb="http://arXiv.org/oai2?verb=someverb",
+  cannotDisseminateFormat="https://pbn.nauka.gov.pl/OAI-PMH?verb=GetRecord&identifier=3&metadataPrefix=oai_dc",
+  idDoesNotExist="http://arXiv.org/oai2?verb=GetRecord&identifier=foobar&metadataPrefix=oai_dc",
+  noRecordsMatch=paste0("http://oai.datacite.org/oai?verb=ListIdentifiers&from=",
+                        tomorrow, "&until=", tomorrow, "&metadataPrefix=oai_dc"),
+  noMetadataFormats=NULL,
+  noSetHierarchy="https://pbn.nauka.gov.pl/OAI-PMH?verb=ListSets"
+)
 
-test_that("badVerb triggers an error", {
-  skip_on_cran()
+# GET and parse
+gnp <- function(u) {
+  r <- httr::GET(u)
+  xml2::read_xml( httr::content(r, "text"))
+}
 
-  res <- httr::GET("http://arXiv.org/oai2/?verb=nastyVerb")
-  txt <- content(res, "text")
-  expect_error( handle_errors( content(res, "text")) )
-  xml <- xml2::read_xml(txt)
-  expect_error( handle_errors2(xml))
 
-  res <- httr::GET("https://pbn.nauka.gov.pl/OAI-PMH?verb=nastyVerb")
-  txt <- content(res, "text")
-  expect_error( handle_errors( content(res, "text")) )
-  xml <- xml2::read_xml(txt)
-  expect_error( handle_errors2(xml) )
+test_that("badArgument is triggered", {
+  xml <- gnp(error_url$badArgument)
+  expect_error( handle_errors(xml) )
+  expect_true( tryCatch( handle_errors(xml), error=function(er) inherits(er, "oai-pmh_error") ) )
+  expect_true( tryCatch( handle_errors(xml), error=function(er) "badArgument" %in% attr(er, "error_codes")))
 } )
+
+
+test_that("badResumptionToken is triggered", {
+  xml <- gnp(error_url$badResumptionToken)
+  expect_error( handle_errors(xml) )
+  expect_true( tryCatch( handle_errors(xml), error=function(er) inherits(er, "oai-pmh_error") ) )
+  expect_true( tryCatch( handle_errors(xml), error=function(er) "badResumptionToken" %in% attr(er, "error_codes")))
+} )
+
+test_that("badVerb is triggered", {
+  xml <- gnp(error_url$badVerb)
+  expect_error( handle_errors(xml) )
+  expect_true( tryCatch( handle_errors(xml), error=function(er) inherits(er, "oai-pmh_error") ) )
+  expect_true( tryCatch( handle_errors(xml), error=function(er) "badVerb" %in% attr(er, "error_codes")))
+} )
+
+test_that("cannotDisseminateFormat is triggered", {
+  xml <- gnp(error_url$cannotDisseminateFormat)
+  expect_error( handle_errors(xml) )
+  expect_true( tryCatch( handle_errors(xml), error=function(er) inherits(er, "oai-pmh_error") ) )
+  expect_true( tryCatch( handle_errors(xml), error=function(er) "cannotDisseminateFormat" %in% attr(er, "error_codes")))
+} )
+
+test_that("idDoesNotExist is triggered", {
+  xml <- gnp(error_url$idDoesNotExist)
+  expect_error( handle_errors(xml) )
+  expect_true( tryCatch( handle_errors(xml), error=function(er) inherits(er, "oai-pmh_error") ) )
+  expect_true( tryCatch( handle_errors(xml), error=function(er) "idDoesNotExist" %in% attr(er, "error_codes")))
+} )
+
+test_that("noRecordsMatch is triggered", {
+  xml <- gnp(error_url$noRecordsMatch)
+  expect_error( handle_errors(xml) )
+  expect_true( tryCatch( handle_errors(xml), error=function(er) inherits(er, "oai-pmh_error") ) )
+  expect_true( tryCatch( handle_errors(xml), error=function(er) "noRecordsMatch" %in% attr(er, "error_codes")))
+} )
+
+
+test_that("noSetHierarchy is triggered", {
+  xml <- gnp(error_url$noSetHierarchy)
+  expect_error( handle_errors(xml) )
+  expect_true( tryCatch( handle_errors(xml), error=function(er) inherits(er, "oai-pmh_error") ) )
+  expect_true( tryCatch( handle_errors(xml), error=function(er) "noSetHierarchy" %in% attr(er, "error_codes")))
+} )
+
+
+
+
+
+
+
+rm(tomorrow, error_url, gnp)

--- a/tests/testthat/test-handle_errors.R
+++ b/tests/testthat/test-handle_errors.R
@@ -22,6 +22,7 @@ gnp <- function(u) {
 
 
 test_that("badArgument is triggered", {
+  skip_on_cran()
   xml <- gnp(error_url$badArgument)
   expect_error( handle_errors(xml) )
   expect_true( tryCatch( handle_errors(xml), error=function(er) inherits(er, "oai-pmh_error") ) )
@@ -30,6 +31,7 @@ test_that("badArgument is triggered", {
 
 
 test_that("badResumptionToken is triggered", {
+  skip_on_cran()
   xml <- gnp(error_url$badResumptionToken)
   expect_error( handle_errors(xml) )
   expect_true( tryCatch( handle_errors(xml), error=function(er) inherits(er, "oai-pmh_error") ) )
@@ -37,6 +39,7 @@ test_that("badResumptionToken is triggered", {
 } )
 
 test_that("badVerb is triggered", {
+  skip_on_cran()
   xml <- gnp(error_url$badVerb)
   expect_error( handle_errors(xml) )
   expect_true( tryCatch( handle_errors(xml), error=function(er) inherits(er, "oai-pmh_error") ) )
@@ -44,6 +47,7 @@ test_that("badVerb is triggered", {
 } )
 
 test_that("cannotDisseminateFormat is triggered", {
+  skip_on_cran()
   xml <- gnp(error_url$cannotDisseminateFormat)
   expect_error( handle_errors(xml) )
   expect_true( tryCatch( handle_errors(xml), error=function(er) inherits(er, "oai-pmh_error") ) )
@@ -51,6 +55,7 @@ test_that("cannotDisseminateFormat is triggered", {
 } )
 
 test_that("idDoesNotExist is triggered", {
+  skip_on_cran()
   xml <- gnp(error_url$idDoesNotExist)
   expect_error( handle_errors(xml) )
   expect_true( tryCatch( handle_errors(xml), error=function(er) inherits(er, "oai-pmh_error") ) )
@@ -58,6 +63,7 @@ test_that("idDoesNotExist is triggered", {
 } )
 
 test_that("noRecordsMatch is triggered", {
+  skip_on_cran()
   xml <- gnp(error_url$noRecordsMatch)
   expect_error( handle_errors(xml) )
   expect_true( tryCatch( handle_errors(xml), error=function(er) inherits(er, "oai-pmh_error") ) )
@@ -66,6 +72,7 @@ test_that("noRecordsMatch is triggered", {
 
 
 test_that("noSetHierarchy is triggered", {
+  skip_on_cran()
   xml <- gnp(error_url$noSetHierarchy)
   expect_error( handle_errors(xml) )
   expect_true( tryCatch( handle_errors(xml), error=function(er) inherits(er, "oai-pmh_error") ) )


### PR DESCRIPTION
Even better handling of OAI-PMH errors: error codes and error messages are stored in a condition object. This will allow to handle different conditions differently somewhere else.