### PR TITLE
Fixed some dates for list_identifiers tests

### DIFF
--- a/tests/testthat/test-list_identifiers.R
+++ b/tests/testthat/test-list_identifiers.R
@@ -3,29 +3,28 @@ context("list_identifiers")
 test_that("list_identifiers - from", {
   skip_on_cran()
 
-  yesterday <- format(Sys.Date()-1, "%Y-%m-%d")
-  aa <- list_identifiers(from = yesterday)
+  aa <- list_identifiers(from = "2015-09-03T00:00:00Z", until="2015-09-03T00:30:00Z")
 
   expect_is(aa, "data.frame")
   expect_is(aa, "oai_df")
   expect_is(aa$identifier, "character")
   expect_is(aa$datestamp, "character")
-  expect_equal(as.character(as.Date(aa$datestamp[1])), yesterday)
+  expect_equal(as.character(as.Date(aa$datestamp[1])), "2015-09-03")
 })
 
 test_that("list_identifiers - from & until", {
   skip_on_cran()
 
-  aa <- list_identifiers(from = '2011-06-01T', until = '2011-06-10T')
-  bb <- list_identifiers(from = '2011-06-01T', until = '2011-07-01T')
-  cc <- list_identifiers(from = '2011-06-01T', until = '2011-10-01T')
+  aa <- list_identifiers(from = '2015-09-03T00:00:00Z', until = '2015-09-03T00:30:00Z')
+  bb <- list_identifiers(from = '2015-09-03T00:30:00Z', until = '2015-09-03T01:15:00Z')
+  cc <- list_identifiers(from = '2015-09-04T00:00:00Z', until = '2015-09-04T02:00:00Z')
 
   expect_is(aa, "oai_df")
   expect_is(bb, "oai_df")
   expect_is(cc, "oai_df")
 
   expect_less_than(NROW(aa), NROW(bb))
-  expect_less_than(NROW(bb), NROW(cc))
+  expect_less_than(NROW(cc), NROW(bb))
 })
 
 test_that("list_identifiers - set", {


### PR DESCRIPTION
Addresses #19 and `list_identifiers`. No need to fetch 7000+ identifiers but fetching still 3-5 requests via `resumptionToken`.

Now when timing tests with `NOT_CRAN=true` I am getting:

```
10            test-providers.R     0.027    0.000   0.030      0.000     0.000
8          test-list_records.R     0.112    0.000   0.269      0.000     0.000
3           test-get_records.R     0.131    0.000   0.353      0.000     0.000
7  test-list_metadataformats.R     0.124    0.000   0.383      0.000     0.000
4         test-handle_errors.R     0.193    0.000   2.026      0.000     0.000
2               test-dumpers.R     0.721    0.021   2.181      0.000     0.000
5                    test-id.R     0.114    0.000   2.654      0.000     0.000
9             test-list_sets.R     1.640    0.012   3.953      0.000     0.000
6      test-list_identifiers.R     2.569    0.023   4.928      0.000     0.000
1     test-count_identifiers.R     0.302    0.011  17.956     13.116     0.095
```